### PR TITLE
Save influence regions

### DIFF
--- a/labelmergeandsplit/splitting_utils.py
+++ b/labelmergeandsplit/splitting_utils.py
@@ -105,7 +105,7 @@ def split_merged_label(in_data, influence_regions):
     :return: data with original split labels
     """
 
-    assert(in_data.shape == influence_regions[list(influence_regions.keys())[0]].shape), \
+    assert(in_data.shape[1:] == influence_regions[list(influence_regions.keys())[0]].shape), \
         (f"Shape mismatch during label splitting: {in_data.shape[1:]} != "
          f"{influence_regions[list(influence_regions.keys())[0]].shape}. The spatial dimensions of the input data must "
          f"match the shape of the influence regions. You may need to register the input data to the reference space of "
@@ -176,6 +176,8 @@ def split_merged_labels_paths_from_influence_region(label_paths_in, label_paths_
     for label_path_in, label_path_out in zip(label_paths_in, label_paths_out):
         in_nii = nib.load(label_path_in)
         in_data = torch.tensor(in_nii.get_fdata()).to("cuda")
+        # input data is expected to be a tensor with shape (C, H, W [, D])
+        in_data = in_data[None, ...]
 
         out_data = split_merged_label(in_data, influence_regions)
 


### PR DESCRIPTION
This PR makes the change to also save the influence_region volume, since it would make the splitting at inference faster.

Otherwise one should read the fuzzy_prior_fudged from disk and compute the influence_region volume.

Aside this small speed improvement, this is very convinient for use case where on wish to upsample the merge label

After upsampling one would then just need to upsamble the influence_region volume in order to perform the split


It is interesting to upsample (and smooth) the label in the onehot format, in order to then perform a argmax. In this case one get memory issue with large number of label, and using the merged label is then a very effective solution

Thanks for sharing this nice code !